### PR TITLE
Render stuff once

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,14 @@ setup(
     package_dir={"": "src"},
     packages=find_packages(where="src"),
     install_requires=[
+        "pyyaml",
         "twisted",
         "treq",
         "txkube",
     ],
+    entry_points={
+        "console_scripts": [
+            "kubetop = kubetop._script:main",
+        ],
+    },
 )

--- a/src/kubetop/_runonce.py
+++ b/src/kubetop/_runonce.py
@@ -1,0 +1,35 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Glue a one-shot function to Twisted's application system.
+"""
+
+from twisted.python.log import err
+from twisted.application.service import Service
+from twisted.internet.defer import maybeDeferred
+
+
+class _RunOnceService(Service):
+    def startService(self):
+        Service.startService(self)
+        self.reactor.callWhenRunning(self._run_and_stop)
+
+
+    def _run_and_stop(self):
+        d = maybeDeferred(self.f)
+        d.addErrback(self._failed)
+        d.addCallback(lambda ignored: self.reactor.stop())
+
+
+    def _failed(self, reason):
+        err(reason)
+        self.main.set_exit_reason(reason)
+
+
+def run_once_service(main, reactor, f):
+    s = _RunOnceService()
+    s.main = main
+    s.reactor = reactor
+    s.f = f
+    return s

--- a/src/kubetop/_script.py
+++ b/src/kubetop/_script.py
@@ -11,3 +11,45 @@ Theory of Operation
 #. Construct the top-level kubetop service from the configuration.
 #. Run the Twisted reactor.
 """
+
+from yaml import safe_load
+
+from os.path import expanduser
+
+from twisted.python.usage import Options
+from twisted.python.filepath import FilePath
+
+from ._twistmain import TwistMain
+from ._runonce import run_once_service
+from ._textrenderer import kubetop
+
+CONFIG = FilePath(expanduser("~/.kube/config"))
+
+
+def current_context(config_path):
+    with config_path.open() as cfg:
+        return safe_load(cfg)[u"current-context"]
+
+
+class KubetopOptions(Options):
+    optParameters = [
+        ("context", None, current_context(CONFIG), "The kubectl context to use."),
+    ]
+
+
+
+def makeService(main, options):
+    from twisted.internet import reactor
+
+    # _topdata imports txkube and treq, both of which import
+    # twisted.web.client, which imports the reactor, which installs a default.
+    # That breaks TwistMain unless we delay it until makeService is called.
+    from ._topdata import make_source
+
+    import sys
+
+    s = make_source(reactor, CONFIG, options["context"])
+    return run_once_service(main, reactor, lambda: kubetop(s, sys.__stdout__))
+
+
+main = TwistMain(KubetopOptions, makeService)

--- a/src/kubetop/_textrenderer.py
+++ b/src/kubetop/_textrenderer.py
@@ -10,3 +10,6 @@ Theory of Operation
 #. Combine a data source with a text-emitting renderer function and a text
    output-capable target (e.g. a file descriptor).
 """
+
+    print("kube top yea")
+def kubetop(datasource, datasink):

--- a/src/kubetop/_textrenderer.py
+++ b/src/kubetop/_textrenderer.py
@@ -11,5 +11,157 @@ Theory of Operation
    output-capable target (e.g. a file descriptor).
 """
 
-    print("kube top yea")
+from __future__ import unicode_literals
+
+from bitmath import Byte
+
+
+COLUMNS = [
+    (20, "POD"),
+    (26, "(CONTAINER)"),
+    (12, "%CPU"),
+    (12, "MEM"),
+    (10, "%MEM")
+]
+
+
 def kubetop(datasource, datasink):
+    return datasource.pods().addCallback(_render_kubetop, datasink)
+
+
+def _render_kubetop(data, sink):
+    sink.write(_render_pod_top(data))
+
+
+def _render_row(*values):
+    fields = []
+    debt = 0
+    for value, (width, label) in zip(values, COLUMNS):
+        field = "{}".format(value).rjust(width - max(0, debt))
+        debt = len(field) - width
+        fields.append(field)
+    return "".join(fields) + "\n"
+
+
+def _render_pod_top(data):
+    return "".join((
+        _render_header(data),
+        _render_pods(data["items"]),
+    ))
+
+
+def _render_header(data):
+    return _render_row(*(
+        label
+        for (width, label)
+        in COLUMNS
+    ))
+
+
+def _render_pods(pods):
+    pod_data = (
+        (_render_pod(pod), _render_containers(pod["containers"]))
+        for pod
+        in sorted(pods, key=_pod_stats, reverse=True)
+    )
+    return "".join(
+        rendered_pod + rendered_containers
+        for (rendered_pod, rendered_containers)
+        in pod_data
+    )
+
+
+def _pod_stats(pod):
+    cpu = sum(
+        map(
+            parse_cpu, (
+                container["usage"]["cpu"]
+                for container
+                in pod["containers"]
+            ),
+        ), 0,
+    )
+    mem = sum(
+        map(
+            parse_memory, (
+                container["usage"]["memory"]
+                for container
+                in pod["containers"]
+            ),
+        ), Byte(0),
+    )
+    return (cpu, mem)
+
+
+def _render_pod(pod):
+    cpu, mem = _pod_stats(pod)
+    return _render_row(
+        pod["metadata"]["name"],
+        "",
+        cpu,
+        _render_memory(mem),
+        mem / Byte(1024),
+    )
+
+
+def _render_containers(containers):
+    return "".join((
+        _render_container(container)
+        for container
+        in sorted(containers, key=lambda c: -parse_cpu(c["usage"]["cpu"]))
+    ))
+
+
+def _render_container(container):
+    return _render_row(
+        "",
+        "(" + container["name"] + ")",
+        container["usage"]["cpu"],
+        _render_memory(parse_memory(container["usage"]["memory"])),
+        "",
+    )
+
+
+def _render_memory(amount):
+    amount = amount.best_prefix()
+    return "{:g} {}".format(float(amount), amount.unit_singular)
+
+
+def partition(seq, pred):
+    return (
+        filter(pred, seq),
+        filter(lambda x: not pred(x), seq),
+    )
+
+
+def parse_cpu(s):
+    return parse_k8s_resource(s)
+
+
+def parse_memory(s):
+    return Byte(parse_k8s_resource(s))
+
+
+def parse_k8s_resource(s):
+    amount, suffix = partition(s, unicode.isdigit)
+    scale = suffix_scale(suffix)
+    return int(amount) * scale
+
+
+def suffix_scale(suffix):
+    return {
+        "": 1,
+        "m": 1,
+        "K": 2 ** 10,
+        "Ki": 2 ** 10,
+        "M": 2 ** 20,
+        "Mi": 2 ** 20,
+        "G": 2 ** 30,
+        "Gi": 2 ** 30,
+        "T": 2 ** 40,
+        "Ti": 2 ** 40,
+        "P": 2 ** 50,
+        "Pi": 2 ** 50,
+        "E": 2 ** 60,
+        "Ei": 2 ** 60,
+    }[suffix]

--- a/src/kubetop/_topdata.py
+++ b/src/kubetop/_topdata.py
@@ -23,7 +23,7 @@ from treq.client import HTTPClient
 from txkube import IKubernetes, network_kubernetes_from_context
 
 
-def source(reactor, config_path, context_name):
+def make_source(reactor, config_path, context_name):
     """
     Get a source of Kubernetes resource usage data.
     """

--- a/src/kubetop/_twistmain.py
+++ b/src/kubetop/_twistmain.py
@@ -58,10 +58,12 @@ class TwistMain(object):
     exit_status = 0
     exit_message = None
 
-
-    def set_exit_reason(self, reason):
-        self.exit_status = 1
-        self.exit_message = reason.getTraceback()
+    def exit(self, reason=None):
+        if reason is not None:
+            self.exit_status = 1
+            self.exit_message = reason.getTraceback()
+        from twisted.internet import reactor
+        reactor.stop()
 
 
     def __call__(self):

--- a/src/kubetop/_twistmain.py
+++ b/src/kubetop/_twistmain.py
@@ -1,0 +1,85 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Adapter from IServiceMaker-like interface to setuptools console-entrypoint
+interface.
+
+Premise
+=======
+
+Given:
+
+* twist is the focus of efforts to make a good client-oriented command-line
+  driver for Twisted-based applications.
+* kubetop is a client-y, command-line, Twisted-based application.
+* Accounting for custom scripts in setup.py with setuptools is a lot harder
+  than just using the ``console_script`` feature.
+
+Therefore:
+
+* Implement application code to the twist interface.
+* Build a single utility for adapting that interface to the ``console_script``
+  interface.
+
+Theory of Operation
+===================
+
+#. Applications provide ``Options`` and ``makeService``, the main pieces of
+  ``IServiceMaker``.
+#. We provide an object which can be called as a ``console_script``
+   entrypoint.
+
+#. That object hooks ``Options`` and ``makeService`` up to the internals of
+   ``twist`` (which are *totally* private, sigh).
+"""
+
+from sys import stdout, argv
+from os.path import expanduser
+
+import attr
+
+from twisted.application.twist import _options
+from twisted.application.twist._twist import Twist
+
+@attr.s(frozen=True)
+class MainService(object):
+    tapname = "kubetop"
+    description = "kubetop"
+    options = attr.ib()
+    makeService = attr.ib()
+
+
+@attr.s
+class TwistMain(object):
+    options = attr.ib()
+    make_service = attr.ib()
+
+    exit_status = 0
+    exit_message = None
+
+
+    def set_exit_reason(self, reason):
+        self.exit_status = 1
+        self.exit_message = reason.getTraceback()
+
+
+    def __call__(self):
+        _options.getPlugins = lambda iface: [
+            MainService(self.options, self._make_service),
+        ]
+
+        t = Twist()
+        t.main([
+            argv[0],
+            b"--log-file", expanduser(b"~/.kubetop.log"),
+            b"kubetop",
+        ] + argv[1:])
+
+        if self.exit_message:
+            stdout.write(self.exit_message)
+        raise SystemExit(self.exit_status)
+
+
+    def _make_service(self, options):
+        return self.make_service(self, options)

--- a/src/kubetop/test/__init__.py
+++ b/src/kubetop/test/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.

--- a/src/kubetop/test/test_textrenderer.py
+++ b/src/kubetop/test/test_textrenderer.py
@@ -78,9 +78,9 @@ class ContainersTests(TestCase):
         }
         self.assertEqual(
             "                    "
-            "                         (foo)"
-            "      100m"
-            "     200Mi"
+            "                     (foo)"
+            "        100m"
+            "     200 MiB"
             "          "
             "\n",
             _render_container(container),

--- a/src/kubetop/test/test_textrenderer.py
+++ b/src/kubetop/test/test_textrenderer.py
@@ -1,0 +1,178 @@
+# Copyright Least Authority Enterprises.
+# See LICENSE for details.
+
+"""
+Tests for ``_textrenderer``.
+"""
+
+from __future__ import unicode_literals
+
+from twisted.trial.unittest import TestCase
+
+from bitmath import Byte
+
+from .._textrenderer import (
+    _render_memory, _render_container, _render_containers, _render_pods,
+)
+
+
+class RenderMemoryTests(TestCase):
+    def test_bytes(self):
+        self.assertEqual(
+            "123 Byte",
+            _render_memory(Byte(123)),
+        )
+
+
+    def test_kibibytes(self):
+        self.assertEqual(
+            "12.5 KiB",
+            _render_memory(Byte(1024 * 12 + 512)),
+        )
+
+
+    def test_mebibytes(self):
+        self.assertEqual(
+            "123.25 MiB",
+            _render_memory(Byte(2 ** 20 * 123 + 2 ** 20 / 4)),
+        )
+
+
+    def test_gibibytes(self):
+        self.assertEqual(
+            "1.05 GiB",
+            _render_memory(Byte(2 ** 30 + 2 ** 30 / 20)),
+        )
+
+
+    def test_tebibytes(self):
+        self.assertEqual(
+            "100 TiB",
+            _render_memory(Byte(2 ** 40 * 100)),
+        )
+
+
+    def test_pebibytes(self):
+        self.assertEqual(
+            "100 PiB",
+            _render_memory(Byte(2 ** 50 * 100)),
+        )
+
+
+    def test_exbibytes(self):
+        self.assertEqual(
+            "100 EiB",
+            _render_memory(Byte(2 ** 60 * 100)),
+        )
+
+
+
+class ContainersTests(TestCase):
+    def test_render_one(self):
+        container = {
+            "name": "foo",
+            "usage": {
+                "cpu": "100m",
+                "memory": "200Mi",
+            },
+        }
+        self.assertEqual(
+            "                    "
+            "                         (foo)"
+            "      100m"
+            "     200Mi"
+            "          "
+            "\n",
+            _render_container(container),
+        )
+
+
+    def test_render_several(self):
+        containers = [
+            {
+                "name": "foo",
+                "usage": {
+                    "cpu": "100m",
+                    "memory": "200Mi",
+                },
+            },
+            {
+                "name": "bar",
+                "usage": {
+                    "cpu": "200m",
+                    "memory": "100Mi",
+                },
+            },
+        ]
+        lines = _render_containers(containers).splitlines()
+        self.assertEqual(
+            ["(bar)", "(foo)"],
+            list(line.split()[0].strip() for line in lines),
+        )
+
+
+
+class PodTests(TestCase):
+    def test_render_several(self):
+        pods = [
+            {
+                "metadata": {
+                    "name": "foo",
+                    "namespace": "default",
+                    "creationTimestamp": "2017-04-07T15:21:22Z"
+                },
+                "timestamp": "2017-04-07T15:21:00Z",
+                "window": "1m0s",
+                "containers": [
+                    {
+                        "name": "foo-a",
+                        "usage": {
+                            "cpu": "100m",
+                            "memory": "50Ki"
+                        }
+                    },
+                    {
+                        "name": "foo-b",
+                        "usage": {
+                            "cpu": "200m",
+                            "memory": "150Ki"
+                        }
+                    }
+                ]
+            },
+            {
+                "metadata": {
+                    "name": "bar",
+                    "namespace": "default",
+                    "creationTimestamp": "2017-04-07T15:21:22Z"
+                },
+                "timestamp": "2017-04-07T15:21:00Z",
+                "window": "1m0s",
+                "containers": [
+                    {
+                        "name": "bar-a",
+                        "usage": {
+                            "cpu": "100m",
+                            "memory": "50Ki"
+                        }
+                    },
+                    {
+                        "name": "bar-b",
+                        "usage": {
+                            "cpu": "500m",
+                            "memory": "10Ki"
+                        }
+                    }
+                ]
+            },
+        ]
+        lines = list(
+            line
+            for line
+            in _render_pods(pods).splitlines()
+            if not line.strip().startswith("(")
+        )
+        self.assertEqual(
+            ["bar", "foo"],
+            list(line.split()[0].strip() for line in lines),
+        )


### PR DESCRIPTION
Fixes #2 

Here's some output produced by this branch:

```
$ kubetop 
                 POD               (CONTAINER)        %CPU         MEM      %MEM
s4-infrastructure-216976705-nkn7r                        1 114.688 MiB  117440.0
                                         (web)          1m 45.5469 MiB          
                                       (flapp)           0 24.8477 MiB          
                              (wormhole-relay)           0 22.8203 MiB          
                       (foolscap-log-gatherer)           0 21.4727 MiB          
image-building-3987116516-g6s93                          0 13.3359 MiB   13656.0
                              (image-building)           0 13.3359 MiB          
```


Note the %MEM column is bull because the code doesn't load information about nodes yet.