### PR TITLE
Add 'config' option to specify different kubectl configs

### DIFF
--- a/src/kubetop/_script.py
+++ b/src/kubetop/_script.py
@@ -26,7 +26,8 @@ from ._twistmain import TwistMain
 from ._runmany import run_many_service
 from ._textrenderer import Sink, kubetop
 
-CONFIG = FilePath(expanduser("~/.kube/config"))
+DEFAULT_CONFIG = "~/.kube/config"
+DEFAULT_CONFIG_FILE_PATH = FilePath(expanduser(DEFAULT_CONFIG))
 
 
 def current_context(config_path):
@@ -36,7 +37,8 @@ def current_context(config_path):
 
 class KubetopOptions(Options):
     optParameters = [
-        ("context", None, current_context(CONFIG), "The kubectl context to use."),
+        ("config", None, DEFAULT_CONFIG, "The path to the kubectl config to use."),
+        ("context", None, current_context(DEFAULT_CONFIG_FILE_PATH), "The kubectl context to use."),
         ("interval", None, 3.0, "The number of seconds between iterations.", float),
         ("iterations", None, None, "The number of iterations to perform.", int),
     ]
@@ -60,7 +62,7 @@ def makeService(main, options):
 
     f = lambda: kubetop(reactor, s, Sink.from_file(outfile))
 
-    s = make_source(reactor, CONFIG, options["context"])
+    s = make_source(reactor, FilePath(expanduser(options["config"])), options["context"])
     return run_many_service(
         main, reactor, f,
         fixed_intervals(options["interval"], options["iterations"]),

--- a/src/kubetop/_script.py
+++ b/src/kubetop/_script.py
@@ -38,10 +38,15 @@ def current_context(config_path):
 class KubetopOptions(Options):
     optParameters = [
         ("config", None, DEFAULT_CONFIG, "The path to the kubectl config to use."),
-        ("context", None, current_context(DEFAULT_CONFIG_FILE_PATH), "The kubectl context to use."),
+        ("context", None, None, "The kubectl context to use. If not set, this will default to the 'current-context' of the 'config'."),
         ("interval", None, 3.0, "The number of seconds between iterations.", float),
         ("iterations", None, None, "The number of iterations to perform.", int),
     ]
+
+    def postOptions(self):
+        # Calculate the context as a post action instead of setting a default value in optParameters since
+        # kubetop should use/show the context of any overridden 'config'
+        self['context'] = current_context(FilePath(expanduser(self['config'])))
 
 
 


### PR DESCRIPTION
My team uses multiple config files and I thought I'd see if you'd be open to adding support to facilitate this approach: by adding a 'config' option to allow users to specify a non-default kubectl config file.

I'm not a python dev and brand new to this project, so apologies in advance if I've trampled over some guidelines/best-practices