### PR TITLE
Replace map() + [], with list(map()) + []

### DIFF
--- a/src/kubetop/_metadata.py
+++ b/src/kubetop/_metadata.py
@@ -1,3 +1,3 @@
 
 version_tuple = (17, 4, 17, 1)
-version_string = ".".join(map(str, version_tuple) + ["dev0"])
+version_string = ".".join(list(map(str, version_tuple)) + ["dev0"])


### PR DESCRIPTION
In Python 3, we cannot do map() + [].

Fixes https://github.com/LeastAuthority/kubetop/issues/56