### PR TITLE
Use twisted.python.compat.unicode since unicode is gone on Python 3

### DIFF
--- a/src/kubetop/_textrenderer.py
+++ b/src/kubetop/_textrenderer.py
@@ -18,6 +18,7 @@ from termios import TIOCGWINSZ
 from fcntl import ioctl
 
 from twisted.internet.defer import gatherResults
+from twisted.python.compat import unicode
 
 from datetime import datetime
 


### PR DESCRIPTION
Fixes #57 