### PR TITLE
Replace filter() with generator + join()

### DIFF
--- a/src/kubetop/_textrenderer.py
+++ b/src/kubetop/_textrenderer.py
@@ -370,8 +370,8 @@ def _render_container(container):
 
 def partition(seq, pred):
     return (
-        filter(pred, seq),
-        filter(lambda x: not pred(x), seq),
+        u"".join(x for x in seq if pred(x)),
+        u"".join(x for x in seq if not pred(x)),
     )
 
 


### PR DESCRIPTION
This fixes the partition() function on Python 3.

Fixes https://github.com/LeastAuthority/kubetop/issues/58