### PR TITLE
Add Python 2.7 requirement to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,8 @@ Installing
 Pip / Pipsi
 ~~~~~~~~~~~
 
+Python 2.7 is required to run kubetop.
+
 To install the latest version of kubetop using `pip`_ or `pipsi`_::
 
   $ pipsi install kubetop


### PR DESCRIPTION
Follow up on: https://github.com/LeastAuthority/kubetop/issues/67

Mention in readme that kubetop requires Python 2.7 to be able to run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/kubetop/68)
<!-- Reviewable:end -->
